### PR TITLE
feat: v0.8.6 Added HFS and Data Element Entry/Subentry Types to free …

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A modern Language Server Protocol (LSP) implementation for IBM SMP/E (System Modification Program/Extended) written in Go.
 
-[![Version](https://img.shields.io/badge/version-0.8.4--alpha-blue.svg)](https://github.com/cybersorcerer/smpe_ls/releases)
+[![Version](https://img.shields.io/badge/version-0.8.6-blue.svg)](https://github.com/cybersorcerer/smpe_ls/releases)
 [![Go Version](https://img.shields.io/badge/Go-1.21+-00ADD8?logo=go)](https://go.dev/)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
 
@@ -130,7 +130,7 @@ See [cmd/smpe_lint/README.md](cmd/smpe_lint/README.md) for full documentation.
 
 ## 🎯 Supported MCS Statements
 
-### Version 0.8.4 (Current)
+### Version 0.8.6 (Current)
 
 **Control MCS (25 statements with full diagnostics):**
 
@@ -222,19 +222,18 @@ make release
 
 ## 📋 What's New
 
-### Version 0.8.4 (Latest)
+### Version 0.8.6 (Latest)
 
 **New Features:**
 
-- 📋 **List Wrapping** - Comma-separated operand lists are automatically wrapped when exceeding a configurable threshold (default: 2 items per line)
-- 🔎 **CodeLens for z/OSMF Queries** - Inline CodeLens actions for querying SYSMODs and DDDEFs via z/OSMF
+- 🌐 **Extended CSI Entry Types** - Free Form CSI Query now supports DLIBZONE, FEATURE, FMIDSET, HOLDDATA, JAR, JARUPD, OPTIONS, ORDER, PRODUCT, PROGRAM, UTILITY, ZONESET with correct subentries
+- 🗂️ **Entry Type Picker** - New radio button picker for Entry Type selection (alphabetically sorted)
+- 🖥️ **HFS Entry Types** - AIX1-5, CLIENT1-5, OS21-5, UNIX1-5, WIN1-5 added to Free Form CSI Query
 
 **Bug Fixes:**
 
-- 🐛 **Parser Crash** - Fixed `slice bounds out of range` panic when formatting files with certain comment patterns
-- 🐛 **Formatting Idempotency** - Second format pass no longer destroys comments; formatting is now stable/idempotent
-- 🐛 **Inline Comment Handling** - Single-line and multi-line inline comments stay with their operand during formatting
-- 🐛 **DELETE Mode DISTLIB Diagnostic** - `++MOD DELETE`, `++SRC DELETE`, `++PROGRAM DELETE` no longer produce false "Missing required operand: DISTLIB" warnings
+- 🐛 **Export JSON/CSV** - Export buttons now work correctly in all query panels (SYSMOD, DDDEF, Zone)
+- 🐛 **Duplicate Emoji in Diagnostics** - Parameter length exceeded diagnostics no longer show two warning emojis
 
 ### Version 0.8.3
 

--- a/client/vscode-smpe/CHANGELOG.md
+++ b/client/vscode-smpe/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project are documented in this file.
 
+## [0.8.6] - 2026-02-25
+
+### Added
+
+- **Extended CSI Entry Types in Free Form Query** - Added DLIBZONE, FEATURE, FMIDSET, HOLDDATA, JAR, JARUPD, OPTIONS, ORDER, PRODUCT, PROGRAM, UTILITY, ZONESET with their correct subentries
+
+### Fixed
+
+- **Duplicate Emoji in Diagnostics** - Parameter length exceeded diagnostics no longer show two warning emojis
+- **activationEvents** - Removed redundant `onLanguage:smpe` activation event (VSCode generates it automatically)
+
+## [0.8.5] - 2026-02-24
+
+### Added
+
+- **HFS Entry Types in Free Form Query** - Added AIX1-5, CLIENT1-5, OS21-5, UNIX1-5, WIN1-5 with their subentries to the Free Form CSI Query
+- **Entry Type Picker** - New radio button picker for Entry Type selection (alphabetically sorted, no groups)
+
+### Fixed
+
+- **Export JSON/CSV** - Export buttons in non-Free Form query panels (SYSMOD, DDDEF, Zone) now work correctly (CSP inline handler fix)
+
 ## [0.8.4-alpha] - 2026
 
 ### Added

--- a/client/vscode-smpe/README.md
+++ b/client/vscode-smpe/README.md
@@ -2,13 +2,13 @@
 
 Language Server Extension for IBM SMP/E MCS (Modification Control Statements).
 
-## What's New in 0.8.4
+## What's New in 0.8.6
 
-- **List Wrapping** - Comma-separated operand lists are automatically wrapped when exceeding a configurable threshold
-- **CodeLens for z/OSMF Queries** - Inline CodeLens actions for querying SYSMODs and DDDEFs via z/OSMF
-- **Formatting Stability** - Formatting is now fully idempotent; inline comments stay with their operands
-- **Parser Crash Fix** - Fixed panic when formatting files with certain comment patterns
-- **DELETE Mode Fix** - `++MOD DELETE`, `++SRC DELETE`, `++PROGRAM DELETE` no longer produce false DISTLIB warnings
+- **Extended CSI Entry Types** - Free Form CSI Query now supports DLIBZONE, FEATURE, FMIDSET, HOLDDATA, JAR, JARUPD, OPTIONS, ORDER, PRODUCT, PROGRAM, UTILITY, ZONESET with correct subentries
+- **Entry Type Picker** - New radio button picker for Entry Type selection (alphabetically sorted)
+- **HFS Entry Types** - AIX1-5, CLIENT1-5, OS21-5, UNIX1-5, WIN1-5 added to Free Form CSI Query
+- **Export Fix** - JSON/CSV export now works correctly in all query panels
+- **Diagnostic Fix** - Parameter length exceeded diagnostics no longer show duplicate warning emoji
 
 See the [CHANGELOG](CHANGELOG.md) for full details.
 
@@ -42,12 +42,12 @@ Download the appropriate `.vsix` file for your platform from the [Release](https
 
 | Platform | File |
 |----------|------|
-| Windows x64 | `vscode-smpe-win32-x64-0.8.4-alpha.vsix` |
-| Windows ARM64 | `vscode-smpe-win32-arm64-0.8.4-alpha.vsix` |
-| macOS Apple Silicon | `vscode-smpe-darwin-arm64-0.8.4-alpha.vsix` |
-| macOS Intel | `vscode-smpe-darwin-x64-0.8.4-alpha.vsix` |
-| Linux x64 | `vscode-smpe-linux-x64-0.8.4-alpha.vsix` |
-| Linux ARM64 | `vscode-smpe-linux-arm64-0.8.4-alpha.vsix` |
+| Windows x64 | `vscode-smpe-win32-x64-0.8.6.vsix` |
+| Windows ARM64 | `vscode-smpe-win32-arm64-0.8.6.vsix` |
+| macOS Apple Silicon | `vscode-smpe-darwin-arm64-0.8.6.vsix` |
+| macOS Intel | `vscode-smpe-darwin-x64-0.8.6.vsix` |
+| Linux x64 | `vscode-smpe-linux-x64-0.8.6.vsix` |
+| Linux ARM64 | `vscode-smpe-linux-arm64-0.8.6.vsix` |
 
 ### Installation in VS Code
 
@@ -59,7 +59,7 @@ Download the appropriate `.vsix` file for your platform from the [Release](https
 Alternatively via terminal:
 
 ```bash
-code --install-extension vscode-smpe-darwin-arm64-0.8.4-alpha.vsix
+code --install-extension vscode-smpe-darwin-arm64-0.8.6.vsix
 ```
 
 The Language Server is already included in the extension - no additional installation required.

--- a/client/vscode-smpe/package-lock.json
+++ b/client/vscode-smpe/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-smpe",
-  "version": "0.8.6-alpha",
+  "version": "0.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-smpe",
-      "version": "0.8.6-alpha",
+      "version": "0.8.6",
       "license": "AGPL-3.0",
       "dependencies": {
         "vscode-languageclient": "^8.1.0",

--- a/client/vscode-smpe/package.json
+++ b/client/vscode-smpe/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-smpe",
   "displayName": "SMP/E Language Support",
   "description": "Language support for SMP/E MCS statements",
-  "version": "0.8.6-alpha",
+  "version": "0.8.6",
   "publisher": "cybersorcerer",
   "license": "AGPL-3.0",
   "repository": {
@@ -19,9 +19,7 @@
   "categories": [
     "Programming Languages"
   ],
-  "activationEvents": [
-    "onLanguage:smpe"
-  ],
+  "activationEvents": [],
   "main": "./out/extension.js",
   "contributes": {
     "languages": [

--- a/cmd/smpe_lint/main.go
+++ b/cmd/smpe_lint/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	version = "v0.8.6-alpha"
+	version = "v0.8.6"
 	commit  = "unknown"
 )
 

--- a/cmd/smpe_ls/main.go
+++ b/cmd/smpe_ls/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	version  = "0.8.6-alpha"
+	version  = "0.8.6"
 	commit   = "unknown" // Set via ldflags: -X main.commit=...
 	debug    = flag.Bool("debug", false, "Enable debug logging")
 	showVer  = flag.Bool("version", false, "Show version")


### PR DESCRIPTION
…form query. Fixed duplicate badges in diagnostics. No additional code changes compared to v0.8.6-alpha. Changelog and READMEs have been updated. This version change is necessary for the plugin to be installed via the VS Code Marketplace.